### PR TITLE
spec: interpret TPM2B_NAME.name as a TPMU_NAME

### DIFF
--- a/src/tpmstream/io/binary/marshal.py
+++ b/src/tpmstream/io/binary/marshal.py
@@ -377,10 +377,17 @@ def process_tpm2b(tpm_type, path, size_constraints=None, abort_on_error=True):
         )
         return size_size, tpm_type(**values)
 
+    selector_value = None
+    if buffer_field.name in getattr(tpm_type, "_selectors", {}):
+        # buffer is union and can be further interpreted
+        selector_name = tpm_type._selectors[buffer_field.name]
+        selector_value = values[selector_name]
+
     try:
         buffer_size, buffer_value = yield from process(
             buffer_field.type,
             path / PathNode(buffer_field.name),
+            selector=selector_value,
             size_constraints=size_constraints,
             abort_on_error=abort_on_error,
         )

--- a/src/tpmstream/spec/structures/structures.py
+++ b/src/tpmstream/spec/structures/structures.py
@@ -140,12 +140,21 @@ class TPM2B_IV:
     buffer: list[BYTE]
 
 
+class TPMU_NAME_SIZE(UINT16):
+    _valid_values = ValidValues(
+        0,
+        TPM_HANDLE._int_size,
+        *sorted(TPM_ALG_ID._int_size + v for v in set(TPMU_HA._list_size.values())),
+    )
+
+    HANDLE = TPM_HANDLE._int_size
+
+
 @tpm_dataclass
 class TPMU_NAME:
-    # TODO look up in TSS?
     _selected_by = {
-        "digest": 1337,
-        "handle": 1337,
+        "digest": None,
+        "handle": TPMU_NAME_SIZE.HANDLE,
     }
 
     digest: TPMT_HA
@@ -154,8 +163,12 @@ class TPMU_NAME:
 
 @tpm_dataclass
 class TPM2B_NAME:
-    size: UINT16
-    name: list[BYTE]
+    _selectors = {
+        "name": "size",
+    }
+
+    size: TPMU_NAME_SIZE
+    name: TPMU_NAME
 
 
 @tpm_dataclass


### PR DESCRIPTION
TPM2B_NAME's name is either empty, a handle of size 4 or a digest.

Interpret .name as a TPMU_NAME with .size as selector for it and change
.size's type to a new helper class to have some safety checks around the
allowed values.

Link: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-2-Version-184_pub.pdf#subsubsection.10.5.3

---

With this patch the output of a `TPM2B_NAME` changes for example from something like this:

```
TPM2B_NAME      |   |   .name
UINT16          |   |   |   .size                 0022                 34
list[BYTE]      |   |   |   .name                 000bc37b19743ef6cc00d4bdb28735800dee8289badc86202e52117a01f8951c9809 ...{.t>.......5........ .R.z......
```

to:

```
TPM2B_NAME      |   |   .name
TPMU_NAME_SIZE  |   |   |   .size                 0022                 34
TPMU_NAME       |   |   |   .name
TPMT_HA         |   |   |   |   .digest
TPMI_ALG_HASH   |   |   |   |   |   .hashAlg      000b                 TPMI_ALG_HASH.SHA256
TPMU_HA         |   |   |   |   |   .digest
list[BYTE]      |   |   |   |   |   |   .sha256   c37b19743ef6cc00d4bdb28735800dee8289badc86202e52117a01f8951c9809 .{.t>.......5........ .R.z......
```

and from:

```
TPM2B_NAME      |   |   .name
UINT16          |   |   |   .size                 0004                 4
list[BYTE]      |   |   |   .name                 80000001             ....
```

to:

```
TPM2B_NAME      |   |   .name
TPMU_NAME_SIZE  |   |   |   .size                 0004                 4
TPMU_NAME       |   |   |   .name
TPM_HANDLE      |   |   |   |   .handle           80000001             TPM_HR.TRANSIENT.000001
```

I opted against `@tpm_enum` for the new `TPMU_NAME_SIZE` class, because the decimal representation seemed more sensible than a string (especially since the algorithm name would be printed right below again) and since multiple algorithms share the same digest size.

PS: Thank you for this great tool!